### PR TITLE
docs: add codemeta.json

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,33 @@
+{
+    "@context": "https://w3id.org/codemeta/3.0",
+    "@type": "SoftwareSourceCode",
+    "license": {
+        "name": "Apache License 2.0",
+        "url": "https://raw.githubusercontent.com/SoftwareUnderstanding/CodeMetaSoft_website/main/LICENSE",
+        "identifier": "https://spdx.org/licenses/Apache-2.0",
+        "spdx_id": "Apache-2.0"
+    },
+    "codeRepository": "https://github.com/SoftwareUnderstanding/CodeMetaSoft_website",
+    "issueTracker": "https://github.com/SoftwareUnderstanding/CodeMetaSoft_website/issues",
+    "dateCreated": "2024-09-03",
+    "dateModified": "2026-01-06",
+    "downloadUrl": "https://github.com/SoftwareUnderstanding/CodeMetaSoft_website/releases",
+    "name": "CodeMetaSoft_website",
+    "programmingLanguage": [
+        "SCSS",
+        "CSS"
+    ],
+    "author": [
+        {
+            "@type": "Organization",
+            "@id": "https://github.com/SoftwareUnderstanding"
+        }
+    ],
+    "url": [
+        "https://w3id.org/codemetasoft"
+    ],
+    "readme": "https://raw.githubusercontent.com/SoftwareUnderstanding/CodeMetaSoft_website/main/README.md",
+    "description": [
+        "A repository for the materials and videos of the CodeMetaSoft project"
+    ]
+}


### PR DESCRIPTION
This PR adds a codemeta.json file to improve findability and indexing in Software Heritage.